### PR TITLE
Removing clair3 temp files to partially address #27

### DIFF
--- a/src/robin/subpages/TargetCoverage_object.py
+++ b/src/robin/subpages/TargetCoverage_object.py
@@ -182,6 +182,7 @@ def run_clair3(bamfile, bedfile, workdir, workdirout, threads, reference, shower
             f"--tumor_bam_fn {bamfile} "
             f"--ref_fn {reference} "
             f"--threads {threads} "
+            f"--remove_intermediate_dir "
             f"--platform ont_r10_guppy_hac_5khz "
             f"--output_dir {workdirout} -b {bedfile}"
             # f" >/dev/null 2>&1"


### PR DESCRIPTION
This should cause clair3 to remove any temporary files after running to help save on disk space and close #27 