### PR TITLE
feat: Introduce model-specific confidence thresholds

### DIFF
--- a/src/robin/subpages/NanoDX_object.py
+++ b/src/robin/subpages/NanoDX_object.py
@@ -256,6 +256,12 @@ class NanoDX_object(BaseAnalysis):
         self.nanodx_df_store = {}  # pd.DataFrame()
         self.nanodxfile = {}
         self.merged_bed_file = {}
+        
+        # Set NanoDX-specific confidence thresholds
+        # NanoDX typically produces lower confidence scores, so adjust thresholds accordingly
+        kwargs['high_confidence_threshold'] = 0.5  # NanoDX-specific high confidence threshold
+        kwargs['medium_confidence_threshold'] = 0.25  # NanoDX-specific medium confidence threshold
+        
         super().__init__(*args, **kwargs)
         if self.model != "Capper_et_al_NN.pkl":
             self.storefile = "PanNanoDX_scores.csv"

--- a/src/robin/subpages/RandomForest_object.py
+++ b/src/robin/subpages/RandomForest_object.py
@@ -292,6 +292,12 @@ class RandomForest_object(BaseAnalysis):
         self.dataDir = {}
         self.bedDir = {}
         self.merged_bed_file = {}
+        
+        # Set RandomForest-specific confidence thresholds
+        # RandomForest confidence is reported as percentage (0-100) but converted to 0-1 in create_summary_card
+        kwargs['high_confidence_threshold'] = 0.85  # RandomForest-specific high confidence threshold
+        kwargs['medium_confidence_threshold'] = 0.65  # RandomForest-specific medium confidence threshold
+        
         super().__init__(*args, **kwargs)
 
     def setup_ui(self):

--- a/src/robin/subpages/Sturgeon_object.py
+++ b/src/robin/subpages/Sturgeon_object.py
@@ -608,6 +608,12 @@ class Sturgeon_object(BaseAnalysis):
             "include/static",
             "probes_{}.bed".format(reference_genome),
         )
+        
+        # Set Sturgeon-specific confidence thresholds
+        # Sturgeon typically gives higher confidence scores, so adjust thresholds accordingly
+        kwargs['high_confidence_threshold'] = 0.8  # Sturgeon-specific high confidence threshold
+        kwargs['medium_confidence_threshold'] = 0.6  # Sturgeon-specific medium confidence threshold
+        
         super().__init__(*args, **kwargs)
 
     def setup_ui(self):

--- a/src/robin/subpages/base_analysis.py
+++ b/src/robin/subpages/base_analysis.py
@@ -112,6 +112,8 @@ class BaseAnalysis:
         uuid: Optional[str] = None,
         force_sampleid: Optional[str] = None,
         sampleID: Optional[str] = None,
+        high_confidence_threshold: float = 0.9,
+        medium_confidence_threshold: float = 0.7,
         *args,
         **kwargs,
     ) -> None:
@@ -129,6 +131,8 @@ class BaseAnalysis:
         self.running = False
         self.force_sampleid = force_sampleid
         self.threads = max(1, threads // 2)
+        self.high_confidence_threshold = high_confidence_threshold
+        self.medium_confidence_threshold = medium_confidence_threshold
         if sampleID:
             self.sampleID = sampleID
             logger.debug(f"SampleID: {self.sampleID}")
@@ -718,18 +722,18 @@ class BaseAnalysis:
 
     def _get_confidence_color(self, confidence):
         """Get color based on confidence level."""
-        if confidence >= 0.9:
+        if confidence >= self.high_confidence_threshold:
             return "#34C759"  # Green for high confidence
-        elif confidence >= 0.7:
+        elif confidence >= self.medium_confidence_threshold:
             return "#007AFF"  # Blue for medium confidence
         else:
             return "#FF9500"  # Orange for low confidence
 
     def _get_confidence_text(self, confidence):
         """Get descriptive text based on confidence level."""
-        if confidence >= 0.9:
+        if confidence >= self.high_confidence_threshold:
             return "High confidence"
-        elif confidence >= 0.7:
+        elif confidence >= self.medium_confidence_threshold:
             return "Medium confidence"
         else:
             return "Low confidence"


### PR DESCRIPTION
- Add configurable high and medium confidence thresholds to BaseAnalysis
- Implement model-specific confidence thresholds for NanoDX, RandomForest, and Sturgeon
- Update confidence color and text methods to use dynamic thresholds
- Enhance flexibility for confidence level interpretation across different models